### PR TITLE
Adds streamgraph and Bayesian surprise paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ At present this list is very biased towards things I am reading for my personal 
 ## Graphs
 
 - [Force-Directed Edge Bundling for Graph Visualization](https://www.win.tue.nl/vis1/home/dholten/papers/forcebundles_eurovis.pdf) - an algorithm for "bundling" edges on node-link diagrams, helps reduce visual clutter
+- [Stacked Graphs – Geometry & Aesthetics](http://leebyron.com/streamgraph/stackedgraphs_byron_wattenberg.pdf) - In this paper Lee Byron & Martin Wattenberg introduce the streamgraph, a new type of stacked chart which was popularized by The New York Times.
 
 ## Human Computer Interaction
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ At present this list is very biased towards things I am reading for my personal 
 
 - [Hypothetical Outcome Plots: Experiencing the Uncertain](https://medium.com/hci-design-at-uw/hypothetical-outcomes-plots-experiencing-the-uncertain-b9ea60d7c740) - a Medium post explaining Hypothetical Outcome Plots (HOPs), an approach to visualizing uncertain data
 - [The Separation Plot: A New Visual Method for Evaluating the Fit of Binary Models](http://mdwardlab.com/sites/default/files/GreenhillWardSacks.pdf) - a visual method for assessing the predictive power of models with binary outcomes
+- [Surprise! Bayesian Weighting for De-Biasing Thematic Maps](https://idl.cs.washington.edu/files/2017-SurpriseMaps-InfoVis.pdf) - an adaptation of Bayesian surprise to generate better thematic maps. Unexpected events are visualized more prominently than those that follow expected patterns.
 
 ## Systems, Toolkits, and Libraries
 


### PR DESCRIPTION
This PR introduces two papers:

# Streamgraph
The Streamgraph is a stacked chart mostly developed by Lee Byron & Martin Wattenberg at the NYT.

http://leebyron.com/streamgraph/stackedgraphs_byron_wattenberg.pdf

## Examples in the wild
- http://www.nytimes.com/interactive/2008/02/23/movies/20080223_REVENUE_GRAPHIC.html

# Bayesian surprise
This paper, by Michael Correll and Jeffrey Heer, creates a new method to improve clarity on thematic maps classification using Bayesian surprise.

https://idl.cs.washington.edu/files/2017-SurpriseMaps-InfoVis.pdf